### PR TITLE
fix(ComposerRequire): Updated to stop dependency issues with 3.2+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
 	"require":
 	{
 		"composer/installers": "*",
-		"silverstripe/framework": "3.1.*",
-		"silverstripe/cms": "3.1.*"
+		"silverstripe/framework": "~3.1",
+		"silverstripe/cms": "~3.1"
 	},
 	"extra": {
 		"installer-name": "rateable"


### PR DESCRIPTION
Updated to stop composer complaining about version mismatch on SS 3.2+ projects.